### PR TITLE
BUGFIX: directly register event-listener for ctrl-k

### DIFF
--- a/Configuration/Settings.Neos.yaml
+++ b/Configuration/Settings.Neos.yaml
@@ -38,8 +38,6 @@ Neos:
         hotkeys:
           # MacOS
           'Shel.Neos.CommandBar.toggle.CMD': 'command+k'
-          # Linux & Windows
-          'Shel.Neos.CommandBar.toggle.CTRL': 'ctrl+k'
 
     modules:
       administration:

--- a/Configuration/Settings.Neos.yaml
+++ b/Configuration/Settings.Neos.yaml
@@ -19,9 +19,6 @@ Neos:
             loadTestCommands: false
           hotkeys:
             filter:
-              # Hide the command bar hotkeys
-              - 'Shel.Neos.CommandBar.toggle.CMD'
-              - 'Shel.Neos.CommandBar.toggle.CTRL'
               # Hide Neos hotkeys which are not relevant in the command bar
               - 'UI.AddNodeModal.close'
               - 'UI.InsertionModeModal.cancel'
@@ -35,9 +32,6 @@ Neos:
               - 'UI.NodeVariantCreationDialog.createEmpty'
               - 'UI.NodeVariantCreationDialog.createAndCopy'
               - 'CR.Nodes.unfocus'
-        hotkeys:
-          # MacOS
-          'Shel.Neos.CommandBar.toggle.CMD': 'command+k'
 
     modules:
       administration:

--- a/packages/ui-plugin/src/CommandBarUiPlugin.tsx
+++ b/packages/ui-plugin/src/CommandBarUiPlugin.tsx
@@ -277,6 +277,15 @@ class CommandBarUiPlugin extends React.PureComponent<CommandBarUiPluginProps, Co
             ...preferences,
             commands: { ...prev.commands, ...commands, ...pluginCommands },
         }));
+
+        // add event-listener directly as the neos-ui hotkey-handling can't prevent defaults
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+                e.stopPropagation();
+                e.preventDefault();
+                this.props.toggleCommandBar();
+            }
+        });
     }
 
     buildCommandsFromHotkeys = (): HierarchicalCommandList => {

--- a/packages/ui-plugin/src/manifest.js
+++ b/packages/ui-plugin/src/manifest.js
@@ -33,9 +33,5 @@ manifest('Shel.Neos.CommandBar:CommandBar', {}, (globalRegistry, { frontendConfi
             description: 'Toggle command bar',
             action: actions.toggleCommandBar,
         });
-        hotkeyRegistry.set('Shel.Neos.CommandBar.toggle.CTRL', {
-            description: 'Toggle command bar',
-            action: actions.toggleCommandBar,
-        });
     }
 });

--- a/packages/ui-plugin/src/manifest.js
+++ b/packages/ui-plugin/src/manifest.js
@@ -1,6 +1,6 @@
 import manifest, { SynchronousRegistry } from '@neos-project/neos-ui-extensibility';
 
-import { reducer, actions } from './actions';
+import { reducer } from './actions';
 import CommandBarUiPlugin from './CommandBarUiPlugin';
 
 manifest('Shel.Neos.CommandBar:CommandBar', {}, (globalRegistry, { frontendConfiguration }) => {
@@ -25,13 +25,4 @@ manifest('Shel.Neos.CommandBar:CommandBar', {}, (globalRegistry, { frontendConfi
 
     // Register reducer
     globalRegistry.get('reducers').set('Shel.Neos.CommandBar', { reducer });
-
-    // Register hotkeys
-    if (frontendConfiguration.hotkeys !== null && frontendConfiguration.hotkeys.length !== 0) {
-        const hotkeyRegistry = globalRegistry.get('hotkeys');
-        hotkeyRegistry.set('Shel.Neos.CommandBar.toggle.CMD', {
-            description: 'Toggle command bar',
-            action: actions.toggleCommandBar,
-        });
-    }
 });


### PR DESCRIPTION
I removed the registration of the ctrl+k hotkey for Neos completely and added the event-handler directly analogous to the module-ui.

Sadly it doesn't seem possible to prevent the default-behavior with the neos-ui hotkey-handling, as neither the event is passed to the handler nor a return value could be set from the handler:
https://github.com/neos/neos-ui/blob/a0683ed157699042aa269ea0819977efafb5be46/packages/neos-ui-sagas/src/UI/Hotkeys/index.js#L14-L16

This PR does not contain a build to avoid conflicts, but I can add it, if preferred.